### PR TITLE
Service endpoints

### DIFF
--- a/app/services/lynk_up_service.rb
+++ b/app/services/lynk_up_service.rb
@@ -26,8 +26,8 @@ class LynkUpService
 
   def add_friend_for_user(id, params)
     response = connection.post("/users/#{id}/friends/") do |con|
-      con.headers = { "CONTENT_TYPE" => "application/json" }
-			con.body = params
+      con.headers = { "Content-Type" => "application/json" }
+			con.body = params.to_json
     end
     JSON.parse(response.body, symbolize_names: true)
   end
@@ -48,8 +48,8 @@ class LynkUpService
 
   def create_group(params)
     response = connection.post("/groups/") do |con|
-      con.headers = { "CONTENT_TYPE" => "application/json" }
-			con.body = params
+      con.headers = { "Content-Type" => "application/json" }
+			con.body = params.to_json
     end
     JSON.parse(response.body, symbolize_names: true)
   end

--- a/spec/fixtures/vcr_cassettes/LynkUpService/add_friend_for_user/returns_a_user_friends_json_object_with_the_added_friend.yml
+++ b/spec/fixtures/vcr_cassettes/LynkUpService/add_friend_for_user/returns_a_user_friends_json_object_with_the_added_friend.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: http://localhost:8000/users/1/friends/
     body:
       encoding: UTF-8
-      string: friend=5
+      string: '{"friend":5}'
     headers:
       Content-Type:
-      - application/x-www-form-urlencoded
+      - application/json
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -21,7 +21,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 30 Jun 2023 20:20:25 GMT
+      - Mon, 03 Jul 2023 22:34:17 GMT
       Server:
       - WSGIServer/0.2 CPython/3.10.11
       Content-Type:
@@ -29,7 +29,7 @@ http_interactions:
       Vary:
       - Accept, origin
       Allow:
-      - GET, OPTIONS, POST
+      - OPTIONS, GET, POST
       X-Frame-Options:
       - DENY
       Content-Length:
@@ -49,5 +49,5 @@ http_interactions:
         Deribeaux","phone_number":"555-222-9999"},{"user_id":7,"user_name":"trevor123","full_name":"Trevor
         Fitzgerald","phone_number":"555-222-3333"},{"user_id":5,"user_name":"dawson123","full_name":"Dawson
         Timmons","phone_number":"555-000-3333"}]}}'
-  recorded_at: Fri, 30 Jun 2023 20:20:25 GMT
+  recorded_at: Mon, 03 Jul 2023 22:34:17 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/LynkUpService/create_group/returns_a_new_group_json_object.yml
+++ b/spec/fixtures/vcr_cassettes/LynkUpService/create_group/returns_a_new_group_json_object.yml
@@ -5,10 +5,10 @@ http_interactions:
     uri: http://localhost:8000/groups/
     body:
       encoding: UTF-8
-      string: name=New+Group&user=1
+      string: '{"user":1,"name":"New Group","friends_list":[{"friend_id":7},{"friend_id":8}]}'
     headers:
       Content-Type:
-      - application/x-www-form-urlencoded
+      - application/json
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -21,7 +21,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 30 Jun 2023 20:40:24 GMT
+      - Mon, 03 Jul 2023 23:55:13 GMT
       Server:
       - WSGIServer/0.2 CPython/3.10.11
       Content-Type:
@@ -29,11 +29,11 @@ http_interactions:
       Vary:
       - Accept, origin
       Allow:
-      - GET, OPTIONS, POST
+      - OPTIONS, GET, POST
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '152'
+      - '344'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -42,7 +42,54 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"id":16,"type":"group","attributes":{"group_host_id":1,"group_host_name":"Andra
-        Helton","group_name":"New Group","group_friends":[],"group_events":[]}}'
-  recorded_at: Fri, 30 Jun 2023 20:40:24 GMT
+      string: '{"id":30,"type":"group","attributes":{"group_host_id":1,"group_host_name":"Andra
+        Helton","group_name":"New Group","group_friends":[{"user_id":7,"user_name":"trevor123","full_name":"Trevor
+        Fitzgerald","phone_number":"555-222-3333"},{"user_id":8,"user_name":"gus123","full_name":"Gus
+        Deribeaux","phone_number":"555-222-9999"}],"group_events":[]}}'
+  recorded_at: Mon, 03 Jul 2023 23:55:13 GMT
+- request:
+    method: post
+    uri: http://localhost:8000/groups/
+    body:
+      encoding: UTF-8
+      string: '{"user":1,"name":"Another New Group"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 03 Jul 2023 23:55:13 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.10.11
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin
+      Allow:
+      - OPTIONS, GET, POST
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '160'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"id":31,"type":"group","attributes":{"group_host_id":1,"group_host_name":"Andra
+        Helton","group_name":"Another New Group","group_friends":[],"group_events":[]}}'
+  recorded_at: Mon, 03 Jul 2023 23:55:13 GMT
 recorded_with: VCR 6.1.0

--- a/spec/services/lynk_up_service_spec.rb
+++ b/spec/services/lynk_up_service_spec.rb
@@ -246,7 +246,9 @@ RSpec.describe LynkUpService do
   end
 
   describe "create_group", :vcr do
-    let(:group) { LynkUpService.new.create_group({user: 1, name: "New Group"}) }
+    let(:group) { LynkUpService.new.create_group({user: 1, name: "New Group", friends_list: [{friend_id: 7}, {friend_id: 8}]}) }
+    let(:group2) { LynkUpService.new.create_group({user: 1, name: "Another New Group"}) }
+
 
     it "returns a new group json object" do
       expect(group).to be_a(Hash)
@@ -260,8 +262,18 @@ RSpec.describe LynkUpService do
       expect(group[:attributes][:group_host_name]).to be_a(String)
       expect(group[:attributes][:group_name]).to be_a(String)
       expect(group[:attributes][:group_name]).to eq("New Group")
-      expect(group[:attributes][:group_friends]).to be_an(Array)
+      expect(group2[:attributes][:group_friends]).to eq([])
+      expect(group[:attributes][:group_friends].count).to eq(2)
+      expect(group[:attributes][:group_friends].first).to be_a(Hash)
+      expect(group[:attributes][:group_friends].first.keys).to eq([:user_id, :user_name, :full_name, :phone_number])
+      expect(group[:attributes][:group_friends][0][:user_id]).to eq(7)
+      expect(group[:attributes][:group_friends][1][:user_id]).to eq(8)
+      expect(group[:attributes][:group_friends][0][:user_id]).to be_an(Integer)
+      expect(group[:attributes][:group_friends][0][:user_name]).to be_a(String)
+      expect(group[:attributes][:group_friends][0][:full_name]).to be_a(String)
+      expect(group[:attributes][:group_friends][0][:phone_number]).to be_a(String)
       expect(group[:attributes][:group_events]).to be_an(Array)
+      expect(group[:attributes][:group_events]).to eq([])
     end
   end
 


### PR DESCRIPTION
Changed connection headers for #add_friend_for_user and #create_group appropriately:

Old headers: con.headers = { "CONTENT_TYPE" => "application/json" } (XML)
New headers: con.headers = { "Content-Type" => "application/json" }

The old headers were not allowing the params to be passed correctly to the server, specifically when creating a group with added friends in the params